### PR TITLE
chore: remove engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,5 @@
     "changed",
     "package.json"
   ],
-  "engines": {
-    "node": ">=6.0.0"
-  },
   "license": "MIT"
 }


### PR DESCRIPTION
This package doesn't actually do anything that requires a specific version of node. Removing `engines` allows code that needs to support legacy users to continue to function.

